### PR TITLE
fix: Fix ceph mon and mgr count

### DIFF
--- a/rook-ceph-cluster-1.13.4/values-override.yaml
+++ b/rook-ceph-cluster-1.13.4/values-override.yaml
@@ -1,9 +1,9 @@
 cephClusterSpec:
   mon:
-    count: 2
+    count: 3
     allowMultiplePerNode: true
   mgr:
-    count: 3
+    count: 2
     allowMultiplePerNode: true
   storage:
     useAllNodes: false


### PR DESCRIPTION
# PR Summary

This PR fixes counts of mon and mgr at example rook-ceph-cluter values-override.yaml